### PR TITLE
feat(plugin-iceberg): Add max-concurrent-file-group-rewrites option for rewrite_data_files

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -1493,25 +1493,31 @@ Rewrite Options
 
 The ``options`` parameter accepts a map of option names to values. The following options are available:
 
-========================== ======== =============== ========================================================================
-Option Name                Type     Default         Description
-========================== ======== =============== ========================================================================
-``min-input-files``        integer  5               Minimum number of files in a partition required for rewriting.
-                                                    Partitions with fewer files are skipped. This is a **group filter**
-                                                    that operates at the partition level.
+===================================== ======== =============== ========================================================================
+Option Name                           Type     Default         Description
+===================================== ======== =============== ========================================================================
+``min-input-files``                   integer  5               Minimum number of files in a partition required for rewriting.
+                                                               Partitions with fewer files are skipped. This is a **group filter**
+                                                               that operates at the partition level.
 
-``min-file-size-bytes``    long     0 (disabled)    Files smaller than this threshold (in bytes) are selected for
-                                                    rewriting. This is a **file filter** that operates on individual
-                                                    files.
+``min-file-size-bytes``               long     0 (disabled)    Files smaller than this threshold (in bytes) are selected for
+                                                               rewriting. This is a **file filter** that operates on individual
+                                                               files.
 
-``max-file-size-bytes``    long     0 (disabled)    Files larger than this threshold (in bytes) are selected for
-                                                    rewriting. This is a **file filter** that operates on individual
-                                                    files.
+``max-file-size-bytes``               long     0 (disabled)    Files larger than this threshold (in bytes) are selected for
+                                                               rewriting. This is a **file filter** that operates on individual
+                                                               files.
 
-``rewrite-all``            boolean  false           When set to ``true``, bypasses all filtering (both group and file
-                                                    level) and rewrites all data files in the table or selected
-                                                    partitions. Useful for simple, complete table rewrites.
-========================== ======== =============== ========================================================================
+``rewrite-all``                       boolean  false           When set to ``true``, bypasses all filtering (both group and file
+                                                               level) and rewrites all data files in the table or selected
+                                                               partitions. Useful for simple, complete table rewrites.
+
+``max-concurrent-file-group-rewrites`` integer 0 (unlimited)   Maximum number of partition groups (file groups) to rewrite
+                                                               concurrently. When set to a positive value, limits concurrent
+                                                               partition processing. A value of ``0`` (default) means unlimited
+                                                               concurrency. **Note:** Apache Iceberg's default is 5, but Presto
+                                                               defaults to 0 (unlimited) for maximum parallelism.
+===================================== ======== =============== ========================================================================
 
 **Filter Behavior:**
 
@@ -1599,6 +1605,22 @@ Examples
   Z-order sorting creates a space-filling curve that interleaves bits from multiple columns,
   providing better data locality for queries that filter on multiple dimensions. This is
   particularly useful for tables with multiple commonly-queried columns.
+
+* Limit concurrent partition processing to 2 partitions at a time::
+
+    CALL iceberg.system.rewrite_data_files(
+        schema => 'db',
+        table_name => 'sample',
+        options => map(
+            array['rewrite-all', 'max-concurrent-file-group-rewrites'],
+            array['true', '2']
+        )
+    );
+
+  Presto defaults to unlimited concurrency (0) for maximum parallelism, while Apache
+  Iceberg's default is 5 concurrent file groups. This option controls partition-level
+  batching during split generation and does not directly control worker-level execution
+  concurrency, which is managed by Presto's scheduler.
 
 Rewrite Manifests
 ^^^^^^^^^^^^^^^^^

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
@@ -109,6 +109,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -257,6 +258,10 @@ public final class IcebergUtil
     protected static final String VIEW_OWNER = "view_owner";
 
     public static final int DEFAULT_MIN_INPUT_FILES = 5;
+    // Default is 0 (unlimited) for maximum parallelism. Apache Iceberg defaults to 5.
+    public static final int DEFAULT_MAX_CONCURRENT_FILE_GROUP_REWRITES = 0;
+    // Sentinel value indicating unlimited concurrency (no limit on active partitions)
+    public static final int UNLIMITED_CONCURRENCY = 0;
 
     private static final Schema LINEAGE_ONLY_SCHEMA = new Schema(LAST_UPDATED_SEQUENCE_NUMBER);
     private static final InclusiveMetricsEvaluator MATCH_ALL_LINEAGE_EVALUATOR =
@@ -1843,25 +1848,59 @@ public final class IcebergUtil
     }
 
     /**
-     * Filters files by partition-level criteria.
-     * Selects files from partitions that have at least min-input-files files.
-     * If rewrite-all is true, skips filtering and returns all tasks.
+     * Parses and validates the max-concurrent-file-group-rewrites option value.
+     * Returns the parsed integer value, or 0 if the option is not present (meaning unlimited).
+     * A value of 0 means unlimited concurrency (no limiting).
+     * When enabling concurrency limiting, Apache Iceberg recommends a value of 5.
+     * <p>
+     * This option controls partition-level batching during split generation, limiting how many
+     * partition groups have their tasks yielded concurrently. It works in conjunction with other
+     * filters (min-input-files, min-file-size-bytes, etc.) which are applied first to determine
+     * which files are eligible for rewriting.
+     * <p>
+     * Note: This controls split generation batching, not worker-level execution concurrency,
+     * which is managed by Presto's scheduler. For unpartitioned tables, all files are in one group,
+     * so this option has no effect.
+     * <p>
+     * <b>Memory consideration:</b> When enabled, this loads all tasks into memory upfront for
+     * grouping by partition. Use with caution on tables with very large numbers of files.
+     *
+     * @param options rewrite options map
+     * @return maximum concurrent file group rewrites, or 0 if not specified (unlimited)
+     * @throws IllegalArgumentException if the value is invalid
+     */
+    public static int parseMaxConcurrentFileGroupRewrites(Map<String, String> options)
+    {
+        String maxConcurrentStr = options.get("max-concurrent-file-group-rewrites");
+        if (maxConcurrentStr == null) {
+            // Not specified = unlimited
+            return UNLIMITED_CONCURRENCY;
+        }
+        try {
+            int maxConcurrent = Integer.parseInt(maxConcurrentStr);
+            if (maxConcurrent < 0) {
+                throw new IllegalArgumentException(
+                    "max-concurrent-file-group-rewrites must be non-negative (0 or unset = unlimited)");
+            }
+            return maxConcurrent;
+        }
+        catch (NumberFormatException e) {
+            throw new IllegalArgumentException(
+                String.format("max-concurrent-file-group-rewrites must be a valid integer, got: %s", maxConcurrentStr), e);
+        }
+    }
+
+    /**
+     * Filters and groups files by partition.
+     * Groups all tasks by partition key, then filters out partitions that don't meet min-input-files threshold.
+     * If rewrite-all is true or min-input-files <= 1, returns all tasks grouped by partition.
      *
      * @param tasks all available tasks
      * @param options rewrite options map
-     * @return files from partitions meeting the criteria
+     * @return map of partition key to list of tasks for partitions meeting the criteria
      */
-    public static CloseableIterable<FileScanTask> filterByGroup(CloseableIterable<FileScanTask> tasks, Map<String, String> options)
+    public static Map<String, List<FileScanTask>> filterAndGroupByPartition(CloseableIterable<FileScanTask> tasks, Map<String, String> options)
     {
-        if (parseRewriteAll(options)) {
-            return tasks;
-        }
-
-        int minInputFiles = parseMinInputFiles(options);
-        if (minInputFiles <= 1) {
-            return tasks;
-        }
-
         // Group files by partition
         Map<String, List<FileScanTask>> partitionGroups = new HashMap<>();
         Map<String, Set<String>> partitionFilePathGroups = new HashMap<>();
@@ -1876,12 +1915,43 @@ public final class IcebergUtil
             throw new UncheckedIOException("Failed to scan table file tasks", e);
         }
 
-        // Collect tasks from partitions that meet the threshold
-        List<FileScanTask> filteredTasks = new ArrayList<>();
+        // If rewrite-all or min-input-files <= 1, return all partitions
+        if (parseRewriteAll(options)) {
+            return partitionGroups;
+        }
+
+        int minInputFiles = parseMinInputFiles(options);
+        if (minInputFiles <= 1) {
+            return partitionGroups;
+        }
+
+        // Filter to partitions that meet the threshold
+        Map<String, List<FileScanTask>> filteredPartitions = new LinkedHashMap<>();
         for (String partitionKey : partitionFilePathGroups.keySet()) {
             if (partitionFilePathGroups.get(partitionKey).size() >= minInputFiles) {
-                filteredTasks.addAll(partitionGroups.get(partitionKey));
+                filteredPartitions.put(partitionKey, partitionGroups.get(partitionKey));
             }
+        }
+        return filteredPartitions;
+    }
+
+    /**
+     * Filters files by partition-level criteria.
+     * Selects files from partitions that have at least min-input-files files.
+     * If rewrite-all is true, skips filtering and returns all tasks.
+     *
+     * @param tasks all available tasks
+     * @param options rewrite options map
+     * @return files from partitions meeting the criteria
+     */
+    public static CloseableIterable<FileScanTask> filterByGroup(CloseableIterable<FileScanTask> tasks, Map<String, String> options)
+    {
+        Map<String, List<FileScanTask>> partitionGroups = filterAndGroupByPartition(tasks, options);
+
+        // Flatten back to a list
+        List<FileScanTask> filteredTasks = new ArrayList<>();
+        for (List<FileScanTask> partitionTasks : partitionGroups.values()) {
+            filteredTasks.addAll(partitionTasks);
         }
         return CloseableIterable.withNoopClose(filteredTasks);
     }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/RewriteDataFilesProcedure.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/RewriteDataFilesProcedure.java
@@ -74,6 +74,7 @@ import static com.facebook.presto.iceberg.IcebergUtil.filterByFile;
 import static com.facebook.presto.iceberg.IcebergUtil.filterByGroup;
 import static com.facebook.presto.iceberg.IcebergUtil.getColumns;
 import static com.facebook.presto.iceberg.IcebergUtil.getFileFormat;
+import static com.facebook.presto.iceberg.IcebergUtil.parseMaxConcurrentFileGroupRewrites;
 import static com.facebook.presto.iceberg.IcebergUtil.parseMaxFileSize;
 import static com.facebook.presto.iceberg.IcebergUtil.parseMinFileSize;
 import static com.facebook.presto.iceberg.IcebergUtil.parseMinInputFiles;
@@ -145,6 +146,7 @@ public class RewriteDataFilesProcedure
                 parseMinFileSize(options);
                 parseMaxFileSize(options);
                 parseRewriteAll(options);
+                parseMaxConcurrentFileGroupRewrites(options);
             }
         }
         return options;

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/splits/RewriteDataFilesIcebergSplitSource.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/splits/RewriteDataFilesIcebergSplitSource.java
@@ -17,34 +17,215 @@ import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.iceberg.IcebergColumnHandle;
 import com.facebook.presto.iceberg.IcebergSplitSource;
 import com.facebook.presto.spi.ConnectorSession;
+import com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.TableScan;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.CloseableIterator;
 
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Queue;
 
+import static com.facebook.presto.iceberg.IcebergUtil.UNLIMITED_CONCURRENCY;
+import static com.facebook.presto.iceberg.IcebergUtil.filterAndGroupByPartition;
 import static com.facebook.presto.iceberg.IcebergUtil.filterByFile;
-import static com.facebook.presto.iceberg.IcebergUtil.filterByGroup;
 import static com.facebook.presto.iceberg.IcebergUtil.getTargetSplitSize;
+import static com.facebook.presto.iceberg.IcebergUtil.parseMaxConcurrentFileGroupRewrites;
 
 /**
- * Split source for rewrite_data_files procedure that applies filtering based on procedure options.
- * Supports file-level filters (min-file-size-bytes, max-file-size-bytes) and group-level filters (min-input-files).
+ * Split source for rewrite_data_files procedure that applies filtering
+ * based on procedure options. Supports file-level filters
+ * (min-file-size-bytes, max-file-size-bytes) and group-level filters
+ * (min-input-files).
+ * <p>
+ * Optionally limits partition-level batching via the
+ * max-concurrent-file-group-rewrites option. When enabled, uses the
+ * already-grouped partition structure from filterAndGroupByPartition and
+ * dynamically activates at most N partitions at a time, yielding tasks
+ * from active partitions sequentially. This controls split generation
+ * batching, not worker-level execution concurrency.
  */
 public class RewriteDataFilesIcebergSplitSource
         extends IcebergSplitSource
 {
+    /**
+     * Creates a split source for the rewrite_data_files procedure with
+     * optional concurrency limiting.
+     *
+     * @param session the connector session
+     * @param tableScan the table scan to generate splits from
+     * @param metadataColumnConstraints metadata column constraints
+     * @param options rewrite procedure options
+     */
     public RewriteDataFilesIcebergSplitSource(
-            ConnectorSession session,
-            TableScan tableScan,
-            TupleDomain<IcebergColumnHandle> metadataColumnConstraints,
-            Map<String, String> options)
+            final ConnectorSession session,
+            final TableScan tableScan,
+            final TupleDomain<IcebergColumnHandle> metadataColumnConstraints,
+            final Map<String, String> options)
     {
-        super(session, getTargetSplitSize(session, tableScan).toBytes(), applyFilters(tableScan, options), metadataColumnConstraints);
+        super(
+                session,
+                getTargetSplitSize(session, tableScan).toBytes(),
+                applyFiltersAndConcurrencyLimit(tableScan, options),
+                metadataColumnConstraints);
     }
 
-    private static CloseableIterable<FileScanTask> applyFilters(TableScan tableScan, Map<String, String> options)
+    /**
+     * Applies file-level filters, groups by partition, applies group-level
+     * filters, then optionally wraps with concurrency limiting.
+     *
+     * @param tableScan the table scan to filter
+     * @param options rewrite options map
+     * @return filtered and optionally concurrency-limited tasks
+     */
+    private static CloseableIterable<FileScanTask>
+            applyFiltersAndConcurrencyLimit(
+                    final TableScan tableScan,
+                    final Map<String, String> options)
     {
-        return filterByGroup(filterByFile(tableScan.planFiles(), options), options);
+        int maxConcurrentFileGroups =
+                parseMaxConcurrentFileGroupRewrites(options);
+
+        // Apply file-level filters first, then group by partition with
+        // partition-level filters
+        Map<String, List<FileScanTask>> partitionGroups =
+                filterAndGroupByPartition(
+                        filterByFile(tableScan.planFiles(), options),
+                        options);
+
+        // If no concurrency limit, just flatten and return all tasks
+        if (maxConcurrentFileGroups <= UNLIMITED_CONCURRENCY) {
+            List<FileScanTask> allTasks = new ArrayList<>();
+            for (List<FileScanTask> partitionTasks : partitionGroups.values()) {
+                allTasks.addAll(partitionTasks);
+            }
+            return CloseableIterable.withNoopClose(allTasks);
+        }
+
+        // Otherwise, wrap with concurrency limiting iterator
+        return new CloseableIterable<FileScanTask>()
+        {
+            @Override
+            public CloseableIterator<FileScanTask> iterator()
+            {
+                return new PartitionLimitingIterator(
+                        partitionGroups, maxConcurrentFileGroups);
+            }
+
+            @Override
+            public void close()
+            {
+            }
+        };
+    }
+
+    /**
+     * Iterator that dynamically activates partitions sequentially.
+     * Works with pre-grouped partition structure from
+     * filterAndGroupByPartition. Maintains at most maxConcurrentPartitions
+     * active partitions, activating new ones as old ones exhaust.
+     * Processes partitions sequentially - exhausts one partition before
+     * moving to the next.
+     */
+    private static class PartitionLimitingIterator
+            implements CloseableIterator<FileScanTask>
+    {
+        /** Map of partition key to list of tasks for that partition. */
+        private final Map<String, List<FileScanTask>> tasks;
+        /** Maximum number of partitions to have active concurrently. */
+        private final int maxConcurrent;
+        /** Queue of partition keys waiting to be activated. */
+        private final Queue<String> pendingPartitions = new LinkedList<>();
+        /** List of currently active partition keys. */
+        private final List<String> activePartitions = new ArrayList<>();
+
+        /**
+         * Creates a partition-limiting iterator.
+         *
+         * @param partitionedTasks map of partition key to tasks
+         * @param maxConcurrentPartitions maximum concurrent partitions
+         */
+        PartitionLimitingIterator(
+                final Map<String, List<FileScanTask>> partitionedTasks,
+                final int maxConcurrentPartitions)
+        {
+            this.tasks = ImmutableMap.copyOf(partitionedTasks);
+            this.maxConcurrent = maxConcurrentPartitions;
+
+            // Initialize pending partitions with all partition keys
+            pendingPartitions.addAll(tasks.keySet());
+
+            // Activate initial set of partitions
+            activateNextPartitions();
+        }
+
+        @Override
+        public boolean hasNext()
+        {
+            // Clean up exhausted partitions and try to activate new ones
+            cleanupAndActivate();
+
+            // Check if any active partition has tasks
+            for (String partition : activePartitions) {
+                if (!tasks.get(partition).isEmpty()) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        @Override
+        public FileScanTask next()
+        {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+
+            // Process the first active partition with tasks
+            for (String partition : activePartitions) {
+                List<FileScanTask> partitionTasks = tasks.get(partition);
+
+                if (partitionTasks != null && !partitionTasks.isEmpty()) {
+                    return partitionTasks.remove(0);
+                }
+            }
+
+            throw new NoSuchElementException();
+        }
+
+        /**
+         * Removes empty partitions from active set and activates new ones.
+         */
+        private void cleanupAndActivate()
+        {
+            activePartitions.removeIf(
+                    partition -> tasks.get(partition).isEmpty());
+            activateNextPartitions();
+        }
+
+        /**
+         * Activates pending partitions up to the maximum concurrent limit.
+         */
+        private void activateNextPartitions()
+        {
+            while (activePartitions.size() < maxConcurrent
+                    && !pendingPartitions.isEmpty()) {
+                String nextPartition = pendingPartitions.poll();
+                if (nextPartition != null
+                        && !tasks.get(nextPartition).isEmpty()) {
+                    activePartitions.add(nextPartition);
+                }
+            }
+        }
+
+        @Override
+        public void close()
+        {
+        }
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestRewriteDataFilesIcebergSplitSource.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestRewriteDataFilesIcebergSplitSource.java
@@ -1,0 +1,271 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.iceberg.procedure.splits.RewriteDataFilesIcebergSplitSource;
+import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.ConnectorSplitSource;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.google.common.collect.ImmutableMap;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.CatalogUtil;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableScan;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.hadoop.HadoopCatalog;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.OptionalInt;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import static com.facebook.presto.iceberg.CatalogType.HADOOP;
+import static com.facebook.presto.iceberg.FileFormat.PARQUET;
+import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
+import static com.facebook.presto.iceberg.IcebergQueryRunner.getIcebergDataDirectoryPath;
+import static java.lang.String.format;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests for RewriteDataFilesIcebergSplitSource concurrency limiting behavior.
+ * <p>
+ * Note: These tests verify split-level batching behavior (which partitions have splits available
+ * at any given time), not the actual worker-level task execution concurrency. The concurrency
+ * limiting primarily affects task scheduling at the worker level, but this is validated through
+ * observing split batch composition.
+ */
+public class TestRewriteDataFilesIcebergSplitSource
+        extends AbstractTestQueryFramework
+{
+    public static final String TEST_SCHEMA = "tpch";
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return IcebergQueryRunner.builder()
+                .setCatalogType(HADOOP)
+                .setFormat(PARQUET)
+                .setNodeCount(OptionalInt.of(1))
+                .setCreateTpchTables(false)
+                .setAddJmxPlugin(false)
+                .build().getQueryRunner();
+    }
+
+    @Test
+    public void testConcurrencyLimitRespectsMaxValueInFirstBatch()
+            throws Exception
+    {
+        String tableName = "test_split_source_concurrency";
+        try {
+            // Create a partitioned table with 5 partitions, MANY files each
+            // This ensures that even with a large batch request, we can observe the limit
+            assertUpdate("CREATE TABLE " + tableName + " (id integer, partition_key varchar) WITH (partitioning = ARRAY['partition_key'])");
+            for (int p = 1; p <= 5; p++) {
+                // Insert 10 rows per partition across 10 separate INSERTs to create 10 files per partition
+                for (int f = 1; f <= 10; f++) {
+                    assertUpdate(format("INSERT INTO %s VALUES (%d, 'p%d')", tableName, p * 100 + f, p), 1);
+                }
+            }
+
+            Table table = loadTable(tableName);
+            TableScan scan = table.newScan();
+
+            // Create split source with max-concurrent-file-group-rewrites=2
+            Map<String, String> options = ImmutableMap.of(
+                    "max-concurrent-file-group-rewrites", "2",
+                    "rewrite-all", "true");
+
+            ConnectorSplitSource splitSource = createSplitSource(scan, options);
+
+            // Request ONLY 3 splits in first batch - this should not be enough to drain 2 partitions
+            // With 10 files per partition and max=2, first batch should only see 2 partitions
+            CompletableFuture<ConnectorSplitSource.ConnectorSplitBatch> futureBatch =
+                    splitSource.getNextBatch(null, 3);
+            ConnectorSplitSource.ConnectorSplitBatch batch = futureBatch.get();
+
+            Set<String> firstBatchPartitions = new HashSet<>();
+            for (ConnectorSplit split : batch.getSplits()) {
+                if (split instanceof IcebergSplit) {
+                    String partitionKey = ((IcebergSplit) split).getPartitionDataJson().orElse("__UNPARTITIONED__");
+                    firstBatchPartitions.add(partitionKey);
+                }
+            }
+
+            // With max=2, first batch of 3 splits should come from at most 2 partitions
+            assertTrue(firstBatchPartitions.size() <= 2,
+                    format("First batch should have at most 2 partitions with max=2, but found %d: %s",
+                            firstBatchPartitions.size(), firstBatchPartitions));
+
+            // Verify we eventually get all 5 partitions
+            Set<String> allPartitions = new HashSet<>(firstBatchPartitions);
+            while (!splitSource.isFinished()) {
+                futureBatch = splitSource.getNextBatch(null, 10);
+                batch = futureBatch.get();
+                for (ConnectorSplit split : batch.getSplits()) {
+                    if (split instanceof IcebergSplit) {
+                        String partitionKey = ((IcebergSplit) split).getPartitionDataJson().orElse("__UNPARTITIONED__");
+                        allPartitions.add(partitionKey);
+                    }
+                }
+            }
+            assertEquals(allPartitions.size(), 5, "Should eventually process all 5 partitions");
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    @Test
+    public void testMaxConcurrentLimitActivatesPartitionsIncrementally()
+            throws Exception
+    {
+        String tableName = "test_max_limit_incremental";
+        try {
+            // Create table with 6 partitions, each with MANY files
+            assertUpdate("CREATE TABLE " + tableName + " (id integer, partition_key varchar) WITH (partitioning = ARRAY['partition_key'])");
+            for (int p = 1; p <= 6; p++) {
+                for (int f = 1; f <= 8; f++) {
+                    assertUpdate(format("INSERT INTO %s VALUES (%d, 'p%d')", tableName, p * 100 + f, p), 1);
+                }
+            }
+
+            Table table = loadTable(tableName);
+            TableScan scan = table.newScan();
+
+            // Set max=3 - should only activate 3 partitions initially
+            Map<String, String> options = ImmutableMap.of(
+                    "max-concurrent-file-group-rewrites", "3",
+                    "rewrite-all", "true");
+
+            ConnectorSplitSource splitSource = createSplitSource(scan, options);
+
+            // Fetch just 4 splits - should come from at most 3 partitions (with 8 files per partition)
+            CompletableFuture<ConnectorSplitSource.ConnectorSplitBatch> futureBatch =
+                    splitSource.getNextBatch(null, 4);
+            ConnectorSplitSource.ConnectorSplitBatch batch = futureBatch.get();
+
+            Set<String> initialPartitions = new HashSet<>();
+            for (ConnectorSplit split : batch.getSplits()) {
+                if (split instanceof IcebergSplit) {
+                    String partitionKey = ((IcebergSplit) split).getPartitionDataJson().orElse("__UNPARTITIONED__");
+                    initialPartitions.add(partitionKey);
+                }
+            }
+
+            // Should see at most 3 partitions in first batch
+            assertTrue(initialPartitions.size() <= 3,
+                    format("First batch should have at most 3 partitions with max=3, but found %d: %s",
+                            initialPartitions.size(), initialPartitions));
+
+            // Continue fetching - should eventually see all 6 partitions
+            Set<String> allPartitions = new HashSet<>(initialPartitions);
+            while (!splitSource.isFinished()) {
+                futureBatch = splitSource.getNextBatch(null, 10);
+                batch = futureBatch.get();
+                for (ConnectorSplit split : batch.getSplits()) {
+                    if (split instanceof IcebergSplit) {
+                        String partitionKey = ((IcebergSplit) split).getPartitionDataJson().orElse("__UNPARTITIONED__");
+                        allPartitions.add(partitionKey);
+                    }
+                }
+            }
+            assertEquals(allPartitions.size(), 6, "Should eventually process all 6 partitions");
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    @Test
+    public void testUnlimitedConcurrencyActivatesAllPartitions()
+            throws Exception
+    {
+        String tableName = "test_unlimited_concurrency";
+        try {
+            // Create table with 5 partitions
+            assertUpdate("CREATE TABLE " + tableName + " (id integer, partition_key varchar) WITH (partitioning = ARRAY['partition_key'])");
+            for (int p = 1; p <= 5; p++) {
+                assertUpdate(format("INSERT INTO %s VALUES (%d, 'p%d')", tableName, p, p), 1);
+            }
+
+            Table table = loadTable(tableName);
+            TableScan scan = table.newScan();
+
+            // No max-concurrent-file-group-rewrites option (unlimited)
+            Map<String, String> options = ImmutableMap.of("rewrite-all", "true");
+
+            ConnectorSplitSource splitSource = createSplitSource(scan, options);
+
+            // With unlimited concurrency, all 5 partitions should be available immediately
+            Set<String> allPartitions = new HashSet<>();
+            CompletableFuture<ConnectorSplitSource.ConnectorSplitBatch> futureBatch =
+                    splitSource.getNextBatch(null, 100);
+            ConnectorSplitSource.ConnectorSplitBatch batch = futureBatch.get();
+
+            for (ConnectorSplit split : batch.getSplits()) {
+                if (split instanceof IcebergSplit) {
+                    String partitionKey = ((IcebergSplit) split).getPartitionDataJson().orElse("__UNPARTITIONED__");
+                    allPartitions.add(partitionKey);
+                }
+            }
+
+            // All 5 partitions should appear in first batch (or very early batches)
+            assertEquals(allPartitions.size(), 5, "All 5 partitions should be active immediately with unlimited concurrency");
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    private ConnectorSplitSource createSplitSource(TableScan scan, Map<String, String> options)
+    {
+        Session session = getQueryRunner().getDefaultSession();
+        RewriteDataFilesIcebergSplitSource splitSource =
+                new RewriteDataFilesIcebergSplitSource(
+                        session.toConnectorSession(new ConnectorId(ICEBERG_CATALOG)),
+                        scan,
+                        com.facebook.presto.common.predicate.TupleDomain.all(),
+                        options);
+        return splitSource;
+    }
+
+    private Table loadTable(String tableName)
+    {
+        Catalog catalog = CatalogUtil.loadCatalog(HadoopCatalog.class.getName(), ICEBERG_CATALOG, getProperties(), new Configuration());
+        return catalog.loadTable(TableIdentifier.of(TEST_SCHEMA, tableName));
+    }
+
+    private Map<String, String> getProperties()
+    {
+        File metastoreDir = getCatalogDirectory();
+        return ImmutableMap.of("warehouse", metastoreDir.toString());
+    }
+
+    private File getCatalogDirectory()
+    {
+        Path dataDirectory = getDistributedQueryRunner().getCoordinator().getDataDirectory();
+        Path catalogDirectory = getIcebergDataDirectoryPath(dataDirectory, HADOOP.name(), new IcebergConfig().getFileFormat(), false);
+        return catalogDirectory.toFile();
+    }
+}

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestRewriteDataFilesProcedure.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestRewriteDataFilesProcedure.java
@@ -1479,6 +1479,170 @@ public class TestRewriteDataFilesProcedure
                 .build();
     }
 
+    @Test
+    public void testMaxConcurrentFileGroupRewrites()
+    {
+        // NOTE: This test validates that the end-to-end procedure completes successfully
+        // and produces the correct final result (correct number of files), but does NOT
+        // verify that the concurrency limiting actually happens during execution.
+        // For tests that verify the split-level concurrency limiting behavior, see
+        // TestRewriteDataFilesIcebergSplitSource.java
+        String tableName = "test_max_concurrent_rewrites";
+        try {
+            // Create a partitioned table with multiple partitions
+            assertUpdate("CREATE TABLE " + tableName + " (id integer, partition_key varchar) WITH (partitioning = ARRAY['partition_key'])");
+
+            // Insert data into 5 different partitions - each INSERT creates one file
+            // Total: 10 inserts = 10 files (2 per partition)
+            assertUpdate("INSERT INTO " + tableName + " VALUES (1, 'p1')", 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (2, 'p1')", 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (3, 'p2')", 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (4, 'p2')", 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (5, 'p3')", 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (6, 'p3')", 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (7, 'p4')", 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (8, 'p4')", 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (9, 'p5')", 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (10, 'p5')", 1);
+
+            Table table = loadTable(tableName);
+
+            // Verify initial state: 10 data files (2 per partition)
+            assertHasDataFiles(table.currentSnapshot(), 10);
+
+            // Test 1: Rewrite with max-concurrent-file-group-rewrites=2
+            // This should limit concurrent partition processing to 2 at a time
+            assertUpdate(format(
+                    "CALL system.rewrite_data_files(table_name => '%s', schema => '%s', " +
+                    "options => map(array['rewrite-all', 'max-concurrent-file-group-rewrites'], array['true', '2']))",
+                    tableName, TEST_SCHEMA), 10);
+
+            table.refresh();
+
+            // After rewrite, should have 5 data files (1 per partition)
+            assertHasDataFiles(table.currentSnapshot(), 5);
+            assertHasDeleteFiles(table.currentSnapshot(), 0);
+
+            // Verify data is preserved
+            assertQuery("SELECT count(*) FROM " + tableName, "VALUES 10");
+            assertQuery("SELECT count(DISTINCT partition_key) FROM " + tableName, "VALUES 5");
+
+            // Test 2: Verify invalid values are rejected
+            assertQueryFails(
+                    format("CALL system.rewrite_data_files(table_name => '%s', schema => '%s', " +
+                          "options => map(array['max-concurrent-file-group-rewrites'], array['-1']))",
+                          tableName, TEST_SCHEMA),
+                    ".*max-concurrent-file-group-rewrites must be non-negative \\(0 or unset = unlimited\\).*");
+
+            assertQueryFails(
+                    format("CALL system.rewrite_data_files(table_name => '%s', schema => '%s', " +
+                          "options => map(array['max-concurrent-file-group-rewrites'], array['invalid']))",
+                          tableName, TEST_SCHEMA),
+                    ".*max-concurrent-file-group-rewrites must be a valid integer.*");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test
+    public void testMaxConcurrentFileGroupRewritesUnpartitioned()
+    {
+        // NOTE: This test validates the end-to-end outcome only, not split-level concurrency behavior.
+        // See TestRewriteDataFilesIcebergSplitSource.java for split-level concurrency tests.
+        String tableName = "test_max_concurrent_unpartitioned";
+        try {
+            // Create an unpartitioned table
+            assertUpdate("CREATE TABLE " + tableName + " (id integer, value varchar)");
+
+            // Insert data to create multiple files
+            assertUpdate("INSERT INTO " + tableName + " VALUES (1, 'a')", 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (2, 'b')", 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (3, 'c')", 1);
+
+            Table table = loadTable(tableName);
+            assertHasDataFiles(table.currentSnapshot(), 3);
+
+            // Rewrite with max-concurrent-file-group-rewrites should work on unpartitioned tables
+            // All files are in one "partition" group, so concurrency limiting has no effect
+            assertUpdate(format(
+                    "CALL system.rewrite_data_files(table_name => '%s', schema => '%s', " +
+                    "options => map(array['rewrite-all', 'max-concurrent-file-group-rewrites'], array['true', '2']))",
+                    tableName, TEST_SCHEMA), 3);
+
+            table.refresh();
+            assertHasDataFiles(table.currentSnapshot(), 1);
+            assertQuery("SELECT count(*) FROM " + tableName, "VALUES 3");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test
+    public void testMaxConcurrentFileGroupRewritesExceedsPartitions()
+    {
+        // NOTE: This test validates the end-to-end outcome only, not split-level concurrency behavior.
+        // See TestRewriteDataFilesIcebergSplitSource.java for split-level concurrency tests.
+        String tableName = "test_max_concurrent_exceeds";
+        try {
+            // Create table with only 2 partitions
+            assertUpdate("CREATE TABLE " + tableName + " (id integer, partition_key varchar) WITH (partitioning = ARRAY['partition_key'])");
+            assertUpdate("INSERT INTO " + tableName + " VALUES (1, 'p1')", 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (2, 'p1')", 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (3, 'p2')", 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (4, 'p2')", 1);
+
+            Table table = loadTable(tableName);
+            assertHasDataFiles(table.currentSnapshot(), 4);
+
+            // Set max=10 but only have 2 partitions - should activate all immediately
+            assertUpdate(format(
+                    "CALL system.rewrite_data_files(table_name => '%s', schema => '%s', " +
+                    "options => map(array['rewrite-all', 'max-concurrent-file-group-rewrites'], array['true', '10']))",
+                    tableName, TEST_SCHEMA), 4);
+
+            table.refresh();
+            assertHasDataFiles(table.currentSnapshot(), 2);
+            assertQuery("SELECT count(*) FROM " + tableName, "VALUES 4");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test
+    public void testRewriteWithoutConcurrencyLimit()
+    {
+        // NOTE: This test validates the end-to-end outcome only, not split-level concurrency behavior.
+        // See TestRewriteDataFilesIcebergSplitSource.java for split-level concurrency tests.
+        String tableName = "test_no_concurrency_limit";
+        try {
+            // Create partitioned table
+            assertUpdate("CREATE TABLE " + tableName + " (id integer, partition_key varchar) WITH (partitioning = ARRAY['partition_key'])");
+            assertUpdate("INSERT INTO " + tableName + " VALUES (1, 'p1')", 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (2, 'p2')", 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (3, 'p3')", 1);
+
+            Table table = loadTable(tableName);
+            assertHasDataFiles(table.currentSnapshot(), 3);
+
+            // Rewrite WITHOUT max-concurrent-file-group-rewrites option
+            // This should use unlimited concurrency (default behavior)
+            assertUpdate(format(
+                    "CALL system.rewrite_data_files(table_name => '%s', schema => '%s', " +
+                    "options => map(array['rewrite-all'], array['true']))",
+                    tableName, TEST_SCHEMA), 3);
+
+            table.refresh();
+            assertHasDataFiles(table.currentSnapshot(), 3);
+            assertQuery("SELECT count(*) FROM " + tableName, "VALUES 3");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
     private Table loadTable(String tableName)
     {
         Catalog catalog = CatalogUtil.loadCatalog(HadoopCatalog.class.getName(), ICEBERG_CATALOG, getProperties(), new Configuration());


### PR DESCRIPTION
## Description

Implements partition-aware concurrency limiting for Iceberg's `rewrite_data_files` procedure via a new `max-concurrent-file-group-rewrites` option. This controls partition-level batching during split generation, limiting how many partition groups are active concurrently during split generation.

### Algorithm: Dynamic Sequential Partition Activation

The implementation leverages the pre-grouped partition structure from filtering and uses dynamic sequential activation to process partitions while respecting concurrency limits.

#### Core Components

1. **Pre-grouped partition structure:**
   - `filterAndGroupByPartition()` groups all `FileScanTask` objects by partition key using `getPartitionKey(FileScanTask)`
   - Returns `Map<String, List<FileScanTask>>` with all partitions already filtered and grouped
   - Eliminates duplicate grouping work (filtering already groups by partition for `min-input-files` checks)

2. **PartitionLimitingIterator:**
   - Works with the pre-grouped partition map
   - Maintains pending partitions (all partition keys initially)
   - Maintains active partitions (at most `maxConcurrentFileGroups` partitions)
   - Sequential processing within active partitions

3. **Dynamic activation flow:**
   - **Initialization:**
     - `pendingPartitions` ← all partition keys
     - Activate first N partitions
   - **On each `next()` call:**
     - Yield next task from first active partition with remaining tasks
     - When partition exhausted:
       - Remove from `activePartitions`
       - Activate next partition from `pendingPartitions`

4. **Sequential processing:** Partitions are processed sequentially - exhausts one partition before moving to the next. This matches the behavior of unlimited mode and provides better locality.

#### Key Behaviors

- **Dynamic activation:** As partitions exhaust, new partitions are immediately activated to maintain the concurrency target
- **Sequential processing:** Processes partitions one at a time (consistent with unlimited mode), providing better locality
- **Task-level grouping:** Works at the `FileScanTask` level before split conversion, using `getPartitionKey(FileScanTask)`
- **No duplicate grouping:** Reuses the partition structure from `filterByGroup`'s existing grouping logic
- **Graceful termination:** Finishes when all active and pending partitions are exhausted
- **Unpartitioned tables:** All files belong to one `__UNPARTITIONED__` group, making concurrency limiting a no-op

#### Memory Characteristics

All tasks are loaded into memory during `filterAndGroupByPartition()`. This was already happening in the original `filterByGroup` implementation—we simply avoid re-grouping them. The grouped structure is kept throughout the concurrency-limited iteration.

**Note:** This controls split generation batching, not worker-level execution concurrency, which is managed by Presto's scheduler.

## Motivation and Context

Requested internally to limit the number of concurrent partitions, and to match Iceberg's implementation.

## Impact

**No Breaking Changes** - New optional parameter with safe defaults:
- **Default:** `0` (unlimited concurrency, bypasses the algorithm entirely for backward compatibility)
- **Apache Iceberg default:** `5`
- **Presto default:** `0` for maximum parallelism
- **Validation:** Rejects negative values, accepts integers ≥ 0

## Test Plan

Includes comprehensive tests validating:

- **Split-level batching behavior** respects concurrency limits (`TestRewriteDataFilesIcebergSplitSource`)
  - Verifies at most N partitions appear in initial batches
  - Confirms dynamic partition activation as earlier partitions exhaust
  - Tests unlimited mode (max=0) activates all partitions immediately
- **End-to-end procedure correctness** (`TestRewriteDataFilesProcedure`)
  - Validates correct final file counts after rewrite with concurrency limiting
  - Tests invalid parameter rejection
- **Edge cases:** unpartitioned tables, limit > partition count, unlimited mode

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely. If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== RELEASE NOTE ==

Iceberg Connector Changes
* Add max-concurrent-file-group-rewrites option to rewrite_data_files procedure for controlling partition-level batching during split generation. Defaults to 0 (unlimited) for backward compatibility.
```
